### PR TITLE
Require Julia v11 to simplify tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PERK"
 uuid = "85f1910e-5d62-11e9-1bce-2b30a05932d4"
-authors = ["Steven Whitaker <stwhit@umich.edu>"]
-version = "0.3.3"
+authors = ["Steven Whitaker <stwhit@umich.edu> and contributors"]
+version = "0.4"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -12,4 +12,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ForwardDiff = "0.10"
 Statistics = "1"
-julia = "1.6"
+julia = "1.11"

--- a/test/estimation.jl
+++ b/test/estimation.jl
@@ -48,7 +48,7 @@ function test_perk_2()
     end
 
     error_rel_avg = sum(error_rel) / length(error_rel)
-    ref = VERSION < v"1.11" ? 0.043934535569840415 : 0.04400107950561938
+    ref = 0.04393452070898947
     @test isapprox(error_rel_avg, ref, atol = 1e-7)
 
 end
@@ -98,8 +98,7 @@ function test_perk_4()
     end
 
     error_rel_avg = sum(error_rel) / length(error_rel)
-    ref = VERSION < v"1.11" ? 0.05827088471817421 : 0.05822451811335079
-
+    ref = 0.058270884718173835
     @test isapprox(error_rel_avg, ref, atol = 1e-7)
 
 end


### PR DESCRIPTION
Tests were failing with v1.11.6 with values that matched several decimal places but to 7 digits.
Anyone who uses < v1.11 can work with an older version of PERK.